### PR TITLE
Modernize bot configuration and startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ COPY ./ /app/
 RUN pip install --no-cache-dir -r requirements.txt
 ENV TELEGRAM_BOT_API_KEY=""
 ENV GEMINI_API_KEYS=""
-CMD ["sh", "-c", "python main.py ${TELEGRAM_BOT_API_KEY} ${GEMINI_API_KEYS}"]
+CMD ["python", "main.py"]

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Required Python packages are listed in [`requirements.txt`](requirements.txt).
    ```bash
    pip install -r requirements.txt
    ```
-2. Run the bot, passing your tokens:
+2. Run the bot. Tokens can be provided either as command line arguments or via environment variables:
    ```bash
-   python main.py <TELEGRAM_BOT_API_KEY> <GEMINI_API_KEY>
+   TELEGRAM_BOT_API_KEY=<telegram token> GEMINI_API_KEYS=<gemini key> python main.py
    ```
 
 ## Docker

--- a/config.py
+++ b/config.py
@@ -1,13 +1,26 @@
+"""Application configuration and Gemini safety settings."""
+
+from dataclasses import dataclass
 from google.genai import types
-conf = {
-    "error_info":           "⚠️⚠️⚠️\nSomething went wrong !\nplease try to change your prompt or contact the admin !",
-    "before_generate_info": "🤖Generating🤖",
-    "download_pic_notify":  "🤖Loading picture🤖",
-    "model_1":              "gemini-2.5-flash-preview-04-17",
-    "model_2":              "gemini-2.5-pro-preview-05-06",
-    "model_3":              "gemini-2.0-flash-preview-image-generation",#for draw
-    "streaming_update_interval": 0.5,  # Streaming answer update interval (seconds)
-}
+
+
+@dataclass(frozen=True)
+class BotConfig:
+    """Immutable container for runtime configuration."""
+
+    error_info: str = (
+        "⚠️⚠️⚠️\nSomething went wrong !\nPlease try to change your prompt or "
+        "contact the admin !"
+    )
+    before_generate_info: str = "🤖Generating🤖"
+    download_pic_notify: str = "🤖Loading picture🤖"
+    model_1: str = "gemini-2.5-flash-preview-04-17"
+    model_2: str = "gemini-2.5-pro-preview-05-06"
+    model_3: str = "gemini-2.0-flash-preview-image-generation"
+    streaming_update_interval: float = 0.5
+
+
+conf = BotConfig()
 
 safety_settings = [
     types.SafetySetting(

--- a/main.py
+++ b/main.py
@@ -1,26 +1,43 @@
+"""Entry point for the Gemini Telegram bot."""
+
 import argparse
 import asyncio
+import os
 import telebot
 from telebot.async_telebot import AsyncTeleBot
 import handlers
-from config import conf
+from config import BotConfig, conf
 
 # Init args
 parser = argparse.ArgumentParser()
-parser.add_argument("tg_token", help="telegram token")
-parser.add_argument("GOOGLE_GEMINI_KEY", help="Google Gemini API key")
+parser.add_argument(
+    "tg_token",
+    nargs="?",
+    default=os.getenv("TELEGRAM_BOT_API_KEY"),
+    help="Telegram token",
+)
+parser.add_argument(
+    "GOOGLE_GEMINI_KEY",
+    nargs="?",
+    default=os.getenv("GOOGLE_GEMINI_KEY") or os.getenv("GEMINI_API_KEYS"),
+    help="Google Gemini API key",
+)
 options = parser.parse_args()
 
 
-async def main():
+async def main() -> None:
+    """Start the bot and register command handlers."""
     # Init bot
+    if not options.tg_token or not options.GOOGLE_GEMINI_KEY:
+        raise SystemExit("API keys must be provided via arguments or environment variables")
+
     bot = AsyncTeleBot(options.tg_token)
     await bot.delete_my_commands(scope=None, language_code=None)
     await bot.set_my_commands(
     commands=[
         telebot.types.BotCommand("start", "Start"),
-        telebot.types.BotCommand("gemini", f"using {conf['model_1']}"),
-        telebot.types.BotCommand("gemini_pro", f"using {conf['model_2']}"),
+        telebot.types.BotCommand("gemini", f"using {conf.model_1}"),
+        telebot.types.BotCommand("gemini_pro", f"using {conf.model_2}"),
         telebot.types.BotCommand("draw", "draw picture"),
         telebot.types.BotCommand("edit", "edit photo"),
         telebot.types.BotCommand("clear", "Clear all history"),


### PR DESCRIPTION
## Summary
- convert `conf` dictionary to `BotConfig` dataclass
- handle API keys via environment variables by default
- add helpful docstrings and type hints
- clean up error handling bugs
- simplify Dockerfile startup

## Testing
- `python -m py_compile config.py gemini.py handlers.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_683f5eb604ec8322968e7c34c737dceb