### PR TITLE
Improve chat session management

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ docker run -d --restart=always \
 - `/start` – greeting message.
 - `/gemini <text>` – ask using the flash model.
 - `/clear` – clear conversation history.
+- Old chats automatically expire after an hour of inactivity.
 
 In private chats you can also send text directly without a command.
 

--- a/config.py
+++ b/config.py
@@ -15,6 +15,8 @@ class BotConfig:
     before_generate_info: str = "🤖Generating🤖"
     model_1: str = "gemini-2.5-flash-preview-05-20"
     streaming_update_interval: float = 0.5
+    # Lifetime of an inactive chat session in seconds
+    session_ttl: float = 3600.0
 
 
 conf = BotConfig()

--- a/handlers.py
+++ b/handlers.py
@@ -11,7 +11,6 @@ error_info = conf.error_info
 before_generate_info = conf.before_generate_info
 model_1 = conf.model_1
 
-gemini_chat_dict = gemini.gemini_chat_dict
 
 
 async def start(message: Message, bot: TeleBot) -> None:
@@ -47,9 +46,7 @@ async def gemini_stream_handler(message: Message, bot: TeleBot) -> None:
 
 async def clear(message: Message, bot: TeleBot) -> None:
     """Clear conversation history for the user."""
-    # Check if the chat is already in gemini_chat_dict.
-    if str(message.from_user.id) in gemini_chat_dict:
-        del gemini_chat_dict[str(message.from_user.id)]
+    gemini.chat_manager.sessions.pop(str(message.from_user.id), None)
     await bot.reply_to(message, "Your history has been cleared")
 
 


### PR DESCRIPTION
## Summary
- add TTL to conversation sessions via new `ChatManager`
- note chat expiry in README
- expose session TTL config option
- streamline clearing chats with new manager

## Testing
- `python -m py_compile *.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f6cdf8a7c8322a11e84c397223029