### PR TITLE
Fix dotenv load order

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,12 +9,12 @@ from dotenv import load_dotenv
 import telebot
 from telebot.async_telebot import AsyncTeleBot
 
+# Load environment from .env if present
+load_dotenv()
+
 import handlers
 from config import conf
 import gemini
-
-# Load environment from .env if present
-load_dotenv()
 
 
 def parse_args() -> argparse.Namespace:


### PR DESCRIPTION
## Summary
- ensure `.env` variables load before importing `config`

## Testing
- `pyflakes .`

------
https://chatgpt.com/codex/tasks/task_e_683f7816c47c8322ac354ad9bc298859