### PR TITLE
Implement whitelist for Telegram bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,9 @@ pip install -r requirements.txt
 TELEGRAM_BOT_API_KEY=<DEIN_TELEGRAM_TOKEN>
 GEMINI_API_KEYS=<DEIN_GEMINI_KEY>
 GEMINI_MODEL=gemini-2.5-flash-preview-05-20
+AUTHORIZED_USER_IDS=12345,67890
 ```
-Das Modell kann jederzeit durch Anpassen von `GEMINI_MODEL` geändert werden. Speichern und die Datei schließen.
+`AUTHORIZED_USER_IDS` ist eine kommaseparierte Liste der Telegram-IDs, die den Bot nutzen dürfen. Das Modell kann jederzeit durch Anpassen von `GEMINI_MODEL` geändert werden. Speichern und die Datei schließen.
 
 ### 6. Bot starten
 
@@ -123,10 +124,14 @@ Ist Docker installiert, lässt sich der Bot auch in einem Container betreiben.
    Zugangsdaten sowie das Modell eintragen:
 
    ```env
-   TELEGRAM_BOT_API_KEY=<DEIN_TELEGRAM_TOKEN>
-   GEMINI_API_KEYS=<DEIN_GEMINI_KEY>
-   GEMINI_MODEL=gemini-2.5-flash-preview-05-20
-   ```
+    TELEGRAM_BOT_API_KEY=<DEIN_TELEGRAM_TOKEN>
+    GEMINI_API_KEYS=<DEIN_GEMINI_KEY>
+    GEMINI_MODEL=gemini-2.5-flash-preview-05-20
+    AUTHORIZED_USER_IDS=12345,67890
+    ```
+    # AUTHORIZED_USER_IDS ist eine kommaseparierte Liste der Telegram-IDs,
+    # die den Bot nutzen dürfen
+
 
 3. Container starten:
 

--- a/config.py
+++ b/config.py
@@ -1,6 +1,6 @@
 """Application configuration and Gemini safety settings."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import os
 from google.genai import types
 
@@ -18,6 +18,13 @@ class BotConfig:
     streaming_update_interval: float = 0.5
     # Lifetime of an inactive chat session in seconds
     session_ttl: float = 3600.0
+    # Comma separated list of allowed Telegram user IDs
+    authorized_user_ids: set[int] = field(default_factory=lambda: {
+        int(uid)
+        for uid in os.getenv("AUTHORIZED_USER_IDS", "").split(",")
+        if uid.strip().isdigit()
+    })
+    access_denied_info: str = "❌ Access denied"
 
 
 conf = BotConfig()

--- a/handlers.py
+++ b/handlers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from telebot import TeleBot
+import asyncio
 from telebot.types import Message
 from md2tgmd import escape
 
@@ -10,11 +11,23 @@ from config import conf
 error_info = conf.error_info
 before_generate_info = conf.before_generate_info
 model_1 = conf.model_1
+authorized_user_ids = conf.authorized_user_ids
+access_denied_info = conf.access_denied_info
+
+
+async def _check_authorized(message: Message, bot: TeleBot) -> bool:
+    """Return True if user is allowed, else reply with denial."""
+    if message.from_user.id in authorized_user_ids:
+        return True
+    await bot.reply_to(message, access_denied_info)
+    return False
 
 
 
 async def start(message: Message, bot: TeleBot) -> None:
     """Send a greeting to the user."""
+    if not await _check_authorized(message, bot):
+        return
 
     try:
         await bot.reply_to(
@@ -30,6 +43,8 @@ async def start(message: Message, bot: TeleBot) -> None:
 
 async def gemini_stream_handler(message: Message, bot: TeleBot) -> None:
     """Handle /gemini command using the flash model."""
+    if not await _check_authorized(message, bot):
+        return
     try:
         m = message.text.strip().split(maxsplit=1)[1].strip()
     except IndexError:
@@ -46,11 +61,15 @@ async def gemini_stream_handler(message: Message, bot: TeleBot) -> None:
 
 async def clear(message: Message, bot: TeleBot) -> None:
     """Clear conversation history for the user."""
+    if not await _check_authorized(message, bot):
+        return
     gemini.chat_manager.sessions.pop(str(message.from_user.id), None)
     await bot.reply_to(message, "Your history has been cleared")
 
 
 async def gemini_private_handler(message: Message, bot: TeleBot) -> None:
     """Handle plain text messages in private chats."""
+    if not await _check_authorized(message, bot):
+        return
     m = message.text.strip()
     await gemini.gemini_stream(bot, message, m, model_1)


### PR DESCRIPTION
## Summary
- add optional `AUTHORIZED_USER_IDS` setting to configuration
- block commands for unauthorized Telegram users
- document whitelist usage in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683f7f5a4b488322be5c7449b164e5bc