### PR TITLE
Persist conversation history until /clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Gesprächsverlauf und zeigt Antworten stückweise an.
 - Chat‑Modell: `gemini-2.5-flash-preview-05-20` (via `GEMINI_MODEL` anpassbar)
 - Streaming‑Antworten für schnelle Rückmeldungen
 - Mehrere Nachrichten pro Unterhaltung
+- Verlauf bleibt gespeichert, bis `/clear` aufgerufen oder der Bot
+  neu gestartet wird
 - Nutzbar in privaten Chats oder Gruppen
 
 ## Voraussetzungen
@@ -168,7 +170,8 @@ und den Container beziehungsweise das Programm neu zu starten.
 - `/start` – Begrüßung
 - `/gemini <Text>` – Frage an den Bot stellen
 - `/clear` – bisherigen Verlauf löschen
-- Unterhaltungen verfallen nach einer Stunde Inaktivität
+- Unterhaltungen bleiben erhalten, bis sie per `/clear` entfernt oder der Bot
+  neu gestartet wird
 
 Im Privatchat können Fragen auch direkt ohne Befehl gesendet werden.
 

--- a/config.py
+++ b/config.py
@@ -16,8 +16,9 @@ class BotConfig:
     before_generate_info: str = "🤖Generating🤖"
     model_1: str = os.getenv("GEMINI_MODEL", "gemini-2.5-flash-preview-05-20")
     streaming_update_interval: float = 0.5
-    # Lifetime of an inactive chat session in seconds
-    session_ttl: float = 3600.0
+    # Lifetime of an inactive chat session in seconds. Set to 0 for unlimited
+    # lifetime. Sessions exist only while the bot process runs.
+    session_ttl: float = 0.0
     # Comma separated list of allowed Telegram user IDs
     authorized_user_ids: set[int] = field(default_factory=lambda: {
         int(uid)

--- a/gemini.py
+++ b/gemini.py
@@ -40,6 +40,8 @@ class ChatManager:
         return chat
 
     def cleanup(self) -> None:
+        if self.ttl <= 0:
+            return
         now = time.monotonic()
         to_remove = [uid for uid, sess in self.sessions.items() if now - sess.last_used > self.ttl]
         for uid in to_remove:


### PR DESCRIPTION
## Summary
- disable session expiration in `BotConfig`
- make `ChatManager.cleanup` a no-op when TTL is 0
- document that histories persist until `/clear`

## Testing
- `python3 -m py_compile config.py gemini.py handlers.py main.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_683f80eb813c8322969bf2f1c0957192