### PR TITLE
Refine menu and start behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,13 +167,11 @@ und den Container beziehungsweise das Programm neu zu starten.
 
 ## Verwendung
 
-- `/start` – Begrüßung
-- `/gemini <Text>` – Frage an den Bot stellen
 - `/clear` – bisherigen Verlauf löschen
 - Unterhaltungen bleiben erhalten, bis sie per `/clear` entfernt oder der Bot
   neu gestartet wird
 
-Im Privatchat können Fragen auch direkt ohne Befehl gesendet werden.
+Im Privatchat können Fragen direkt ohne Befehl gesendet werden.
 
 ## Lizenz
 

--- a/handlers.py
+++ b/handlers.py
@@ -24,21 +24,6 @@ async def _check_authorized(message: Message, bot: TeleBot) -> bool:
 
 
 
-async def start(message: Message, bot: TeleBot) -> None:
-    """Send a greeting to the user."""
-    if not await _check_authorized(message, bot):
-        return
-
-    try:
-        await bot.reply_to(
-            message,
-            escape(
-                "Welcome, you can ask me questions now. \nFor example: `Who is john lennon?`"
-            ),
-            parse_mode="MarkdownV2",
-        )
-    except IndexError:
-        await bot.reply_to(message, error_info)
 
 
 async def gemini_stream_handler(message: Message, bot: TeleBot) -> None:
@@ -50,9 +35,7 @@ async def gemini_stream_handler(message: Message, bot: TeleBot) -> None:
     except IndexError:
         await bot.reply_to(
             message,
-            escape(
-                "Please add what you want to say after /gemini. \nFor example: `/gemini Who is john lennon?`"
-            ),
+            escape("Please add what you want to say after /gemini."),
             parse_mode="MarkdownV2",
         )
         return

--- a/main.py
+++ b/main.py
@@ -57,13 +57,10 @@ async def main() -> None:
     await bot.delete_my_commands(scope=None, language_code=None)
     await bot.set_my_commands(
         commands=[
-            telebot.types.BotCommand("start", "Start"),
-            telebot.types.BotCommand("gemini", f"using {conf.model_1}"),
             telebot.types.BotCommand("clear", "Clear all history"),
         ],
     )
     # Init commands
-    bot.register_message_handler(handlers.start, commands=["start"], pass_bot=True)
     bot.register_message_handler(
         handlers.gemini_stream_handler, commands=["gemini"], pass_bot=True
     )


### PR DESCRIPTION
## Summary
- simplify README usage instructions
- drop `/start` greeting handler and remove Gemini model from command menu
- sanitize help text example
- register only `/clear` in command menu

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683f92550c28832294f6e6ef271c39e3