### PR TITLE
Refine menu and start behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,15 +165,20 @@ Google veröffentlicht regelmäßig neue Gemini‑Modelle. Um ein anderes Modell
 nutzen, reicht es, den Namen in der `.env`‑Datei bei `GEMINI_MODEL` anzupassen
 und den Container beziehungsweise das Programm neu zu starten.
 
+Die voreingestellten Sicherheitsfilter des Modells sind in `config.py` auf
+`BLOCK_NONE` gesetzt und damit komplett deaktiviert. Bei Bedarf lassen sie sich
+dort anpassen.
+
 ## Verwendung
 
-- `/start` – Begrüßung
-- `/gemini <Text>` – Frage an den Bot stellen
 - `/clear` – bisherigen Verlauf löschen
 - Unterhaltungen bleiben erhalten, bis sie per `/clear` entfernt oder der Bot
   neu gestartet wird
 
-Im Privatchat können Fragen auch direkt ohne Befehl gesendet werden.
+Im Privatchat können Fragen direkt ohne Befehl gesendet werden. Bilder können
+ebenfalls geschickt werden. Liegt dem Bild eine Frage oder Beschreibung bei,
+nutzt der Bot diese zur Analyse. Andernfalls gibt er eine kurze Beschreibung
+des Bildes zurück.
 
 ## Lizenz
 

--- a/main.py
+++ b/main.py
@@ -57,21 +57,21 @@ async def main() -> None:
     await bot.delete_my_commands(scope=None, language_code=None)
     await bot.set_my_commands(
         commands=[
-            telebot.types.BotCommand("start", "Start"),
-            telebot.types.BotCommand("gemini", f"using {conf.model_1}"),
             telebot.types.BotCommand("clear", "Clear all history"),
         ],
     )
     # Init commands
-    bot.register_message_handler(handlers.start, commands=["start"], pass_bot=True)
     bot.register_message_handler(
-        handlers.gemini_stream_handler, commands=["gemini"], pass_bot=True
+        handlers.gemini_stream_handler,
+        commands=["gemini"],
+        pass_bot=True,
+        content_types=["text", "photo", "document"],
     )
     bot.register_message_handler(handlers.clear, commands=["clear"], pass_bot=True)
     bot.register_message_handler(
         handlers.gemini_private_handler,
         func=lambda message: message.chat.type == "private",
-        content_types=["text"],
+        content_types=["text", "photo", "document"],
         pass_bot=True,
     )
 


### PR DESCRIPTION
## Summary
- simplify README usage instructions
- drop `/start` greeting handler and remove Gemini model from command menu
- sanitize help text example
- register only `/clear` in command menu
- support image understanding by accepting photos/documents

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_683f92550c28832294f6e6ef271c39e3