### PR TITLE
Add image understanding to Telegram bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Gesprächsverlauf und zeigt Antworten stückweise an.
 - Mehrere Nachrichten pro Unterhaltung
 - Verlauf bleibt gespeichert, bis `/clear` aufgerufen oder der Bot
   neu gestartet wird
+- Bilder verstehen: Fotos oder Bilddateien können mit oder ohne Bildunterschrift
+  gesendet werden. Die Caption wird als Prompt genutzt und das Ergebnis als
+  Antwort ausgegeben.
 - Nutzbar in privaten Chats oder Gruppen
 
 ## Voraussetzungen
@@ -172,6 +175,8 @@ und den Container beziehungsweise das Programm neu zu starten.
   neu gestartet wird
 
 Im Privatchat können Fragen direkt ohne Befehl gesendet werden.
+Fotos oder Bilddateien können ebenfalls geschickt werden. Eine angefügte
+Beschriftung dient dabei als Prompt für Gemini.
 
 ## Lizenz
 

--- a/gemini.py
+++ b/gemini.py
@@ -74,9 +74,16 @@ def _ensure_client() -> genai.Client:
 
 
 async def gemini_stream(
-    bot: TeleBot, message: Message, query: str, model_type: str
+    bot: TeleBot,
+    message: Message,
+    query: object,
+    model_type: str,
 ) -> None:
-    """Stream a chat response from Gemini and edit the message as chunks arrive."""
+    """Stream a chat response from Gemini.
+
+    ``query`` may be a plain string or a list of ``types.Part`` objects mixed
+    with strings for multimodal prompts.
+    """
 
     sent_message: Message | None = None
     try:

--- a/main.py
+++ b/main.py
@@ -71,6 +71,11 @@ async def main() -> None:
         content_types=["text"],
         pass_bot=True,
     )
+    bot.register_message_handler(
+        handlers.gemini_image_handler,
+        content_types=["photo", "document"],
+        pass_bot=True,
+    )
 
     # Start bot
     logger.info("Starting Gemini_Telegram_Bot.")


### PR DESCRIPTION
## Summary
- allow photos and image documents to be processed by Gemini
- update streaming helper to accept images
- document new feature in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683f974a9a748322b449b5a043db1cc9