### PR TITLE
Add Gemini safety settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,13 @@ GEMINI_API_KEYS=<DEIN_GEMINI_KEY>
 GEMINI_MODEL=gemini-2.5-flash-preview-05-20
 AUTHORIZED_USER_IDS=12345,67890
 ```
+
 `AUTHORIZED_USER_IDS` ist eine kommaseparierte Liste der Telegram-IDs, die den Bot nutzen dürfen. Das Modell kann jederzeit durch Anpassen von `GEMINI_MODEL` geändert werden. Speichern und die Datei schließen.
+
+### Sicherheitseinstellungen
+
+Alle Safety-Filter der Gemini-API sind im Auslieferungszustand deaktiviert (`BLOCK_NONE`). Die entsprechenden
+Einstellungen stehen in `config.py` und lassen sich bei Bedarf ändern.
 
 ### 6. Bot starten
 

--- a/gemini.py
+++ b/gemini.py
@@ -10,9 +10,9 @@ from typing import Dict, Optional
 from telebot import TeleBot
 from telebot.types import Message
 from google import genai
-from google.genai import chats
+from google.genai import chats, types
 
-from config import conf
+from config import conf, safety_settings
 from utils import safe_edit
 
 
@@ -35,7 +35,13 @@ class ChatManager:
             return session.chat
 
         client = _ensure_client()
-        chat = client.aio.chats.create(model=model, config={"tools": [search_tool]})
+        chat = client.aio.chats.create(
+            model=model,
+            config=types.GenerateContentConfig(
+                tools=[search_tool],
+                safety_settings=safety_settings,
+            ),
+        )
         self.sessions[user_id] = ChatSession(chat)
         return chat
 


### PR DESCRIPTION
## Summary
- add safety config in README
- configure ChatManager to use safety settings so the API doesn't filter content

## Testing
- `python -m py_compile gemini.py config.py handlers.py utils.py main.py`
- `pip install -q -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_683f9884cfec8322a1240d31b9f75c5b