### PR TITLE
Add YouTube video question support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Gesprächsverlauf und zeigt Antworten stückweise an.
 - Bilder verstehen: Fotos oder Bilddateien können mit oder ohne Bildunterschrift
   gesendet werden. Die Caption wird als Prompt genutzt und das Ergebnis als
   Antwort ausgegeben.
+- YouTube-Videos analysieren: Link mit /youtube und Frage schicken oder erst den
+  Link senden und danach die Frage stellen
 - Nutzbar in privaten Chats oder Gruppen
 
 ## Voraussetzungen
@@ -183,6 +185,8 @@ und den Container beziehungsweise das Programm neu zu starten.
 Im Privatchat können Fragen direkt ohne Befehl gesendet werden.
 Fotos oder Bilddateien können ebenfalls geschickt werden. Eine angefügte
 Beschriftung dient dabei als Prompt für Gemini.
+YouTube-Links funktionieren ähnlich: einfach den Link senden, dann eine Frage
+nachschieben, oder den Befehl `/youtube` mit Link und Frage nutzen.
 
 ## Lizenz
 

--- a/gemini.py
+++ b/gemini.py
@@ -124,3 +124,18 @@ async def gemini_stream(
             )
         else:
             await bot.reply_to(message, f"{error_info}\nError details: {exc}")
+
+
+async def gemini_youtube_stream(
+    bot: TeleBot,
+    message: Message,
+    youtube_url: str,
+    prompt: str,
+    model_type: str,
+) -> None:
+    """Stream a response based on the provided YouTube video and prompt."""
+
+    video_part = types.Part(
+        file_data=types.FileData(file_uri=youtube_url)
+    )
+    await gemini_stream(bot, message, [video_part, prompt], model_type)

--- a/handlers.py
+++ b/handlers.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from telebot import TeleBot
 from telebot.types import Message
 from google.genai import types
+import re
 from md2tgmd import escape
 
 import gemini
@@ -13,6 +14,12 @@ before_generate_info = conf.before_generate_info
 model_1 = conf.model_1
 authorized_user_ids = conf.authorized_user_ids
 access_denied_info = conf.access_denied_info
+
+# Map user ID to pending YouTube URL awaiting a prompt
+pending_youtube: dict[int, str] = {}
+
+# Simple regex to detect YouTube links
+YOUTUBE_RE = re.compile(r"https?://(?:www\.)?(?:youtube\.com/watch\?v=|youtu\.be/)[^\s]+")
 
 
 async def _check_authorized(message: Message, bot: TeleBot) -> bool:
@@ -42,6 +49,29 @@ async def gemini_stream_handler(message: Message, bot: TeleBot) -> None:
     await gemini.gemini_stream(bot, message, m, model_1)
 
 
+async def youtube_command_handler(message: Message, bot: TeleBot) -> None:
+    """Handle /youtube command with a video URL and optional prompt."""
+    if not await _check_authorized(message, bot):
+        return
+    parts = message.text.strip().split(maxsplit=2)
+    if len(parts) < 2 or not YOUTUBE_RE.search(parts[1]):
+        await bot.reply_to(
+            message,
+            escape("Please provide a valid YouTube URL after /youtube."),
+            parse_mode="MarkdownV2",
+        )
+        return
+
+    url = parts[1]
+    if len(parts) == 2:
+        pending_youtube[message.from_user.id] = url
+        await bot.reply_to(message, "What would you like to do with this video?")
+        return
+
+    prompt = parts[2].strip()
+    await gemini.gemini_youtube_stream(bot, message, url, prompt, model_1)
+
+
 async def clear(message: Message, bot: TeleBot) -> None:
     """Clear conversation history for the user."""
     if not await _check_authorized(message, bot):
@@ -55,6 +85,26 @@ async def gemini_private_handler(message: Message, bot: TeleBot) -> None:
     if not await _check_authorized(message, bot):
         return
     m = message.text.strip()
+
+    # If user previously sent a YouTube link without a prompt
+    if message.from_user.id in pending_youtube and not YOUTUBE_RE.search(m):
+        url = pending_youtube.pop(message.from_user.id)
+        await gemini.gemini_youtube_stream(bot, message, url, m, model_1)
+        return
+
+    # Message contains a YouTube link
+    match = YOUTUBE_RE.search(m)
+    if match:
+        url = match.group(0)
+        prompt = m[match.end():].strip()
+        if not prompt:
+            pending_youtube[message.from_user.id] = url
+            await bot.reply_to(message, "What would you like to do with this video?")
+            return
+        await gemini.gemini_youtube_stream(bot, message, url, prompt, model_1)
+        return
+
+    # Regular text
     await gemini.gemini_stream(bot, message, m, model_1)
 
 

--- a/main.py
+++ b/main.py
@@ -58,11 +58,15 @@ async def main() -> None:
     await bot.set_my_commands(
         commands=[
             telebot.types.BotCommand("clear", "Clear all history"),
+            telebot.types.BotCommand("youtube", "Ask about a YouTube video"),
         ],
     )
     # Init commands
     bot.register_message_handler(
         handlers.gemini_stream_handler, commands=["gemini"], pass_bot=True
+    )
+    bot.register_message_handler(
+        handlers.youtube_command_handler, commands=["youtube", "yt"], pass_bot=True
     )
     bot.register_message_handler(handlers.clear, commands=["clear"], pass_bot=True)
     bot.register_message_handler(


### PR DESCRIPTION
## Summary
- support video URLs with new `/youtube` command or by sending the link first
- handle YouTube links in private chats
- add helper to stream answers for YouTube videos
- document the new ability in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683f9a3739088322bb982679bdd58a01