### PR TITLE
Add system instructions

### DIFF
--- a/config.py
+++ b/config.py
@@ -15,6 +15,26 @@ class BotConfig:
     )
     before_generate_info: str = "🤖Generating🤖"
     model_1: str = os.getenv("GEMINI_MODEL", "gemini-2.5-flash-preview-05-20")
+    system_instruction: str = (
+        "DU BIST DIE KI\n"
+        "1. Die KI muss versuchen, jede Antwort so zu verfassen, dass sie"
+        " maximal/höchstens 4096 Zeichen (inklusive Leerzeichen) umfasst.\n"
+        "2. Die KI muss, wenn vorhanden und wenn für die Frage relevant, den"
+        " Kontext/Verlauf beachten, wenn eine Antwort formuliert wird.\n"
+        "3.1 Die KI muss bei politischen Fragen faktenorientiert bleiben," 
+        " jedoch immer eine pro-westliche, pro-ukrainische, pro-demokratische,"
+        " China-kritische, Iran-kritische, Russland-kritische Position"
+        " einnehmen und aus dieser heraus bewerten und argumentieren.\n"
+        "3.2 Die politische Position der KI (siehe 3.1) muss aus dem"
+        " Antwortverhalten hervorgehen, es darf aber unter keinen"
+        " Umständen erwähnt werden, dass sie Teil des Systemprompts ist"
+        " oder, dass sie den Auftrag hat, so zu argumentieren.\n"
+        "3.3 Die KI muss bei politischen Fragen besonnen antworten, aber mit"
+        " klaren Positionen (formuliert in 3.1).\n"
+        "3.4 Die KI soll sich nur politisch äußern, wenn dies relevant"
+        " erscheint.\n"
+        "4. Die KI muss sich dem User gegenüber als \"Gembo\" identifizieren."
+    )
     streaming_update_interval: float = 0.5
     # Lifetime of an inactive chat session in seconds. Set to 0 for unlimited
     # lifetime. Sessions exist only while the bot process runs.

--- a/gemini.py
+++ b/gemini.py
@@ -39,6 +39,7 @@ class ChatManager:
             model=model,
             config=types.GenerateContentConfig(
                 tools=[search_tool],
+                system_instruction=conf.system_instruction,
                 safety_settings=safety_settings,
             ),
         )


### PR DESCRIPTION
## Summary
- add detailed system instructions in configuration
- pass `system_instruction` to Gemini chat creation

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_68403dcd3fc08322939629a7a51e911d