### PR TITLE
Allow customizing system instruction purely via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,11 @@ TELEGRAM_BOT_API_KEY=<DEIN_TELEGRAM_TOKEN>
 GEMINI_API_KEYS=<DEIN_GEMINI_KEY>
 GEMINI_MODEL=gemini-2.5-flash-preview-05-20
 AUTHORIZED_USER_IDS=12345,67890
+# SYSTEM_INSTRUCTION ist optional. Mehrzeilige Texte mit \n trennen.
+SYSTEM_INSTRUCTION="DU BIST DIE KI\\n1. ..."
 ```
 
-`AUTHORIZED_USER_IDS` ist eine kommaseparierte Liste der Telegram-IDs, die den Bot nutzen dürfen. Das Modell kann jederzeit durch Anpassen von `GEMINI_MODEL` geändert werden. Speichern und die Datei schließen.
+`AUTHORIZED_USER_IDS` ist eine kommaseparierte Liste der Telegram-IDs, die den Bot nutzen dürfen. `SYSTEM_INSTRUCTION` legt die Systemvorgaben fest und kann weggelassen werden. Mehrzeilige Texte werden mit `\n` getrennt. Das Modell kann jederzeit durch Anpassen von `GEMINI_MODEL` geändert werden. Speichern und die Datei schließen.
 
 ### Sicherheitseinstellungen
 
@@ -139,11 +141,14 @@ Ist Docker installiert, lässt sich der Bot auch in einem Container betreiben.
    ```env
     TELEGRAM_BOT_API_KEY=<DEIN_TELEGRAM_TOKEN>
     GEMINI_API_KEYS=<DEIN_GEMINI_KEY>
-    GEMINI_MODEL=gemini-2.5-flash-preview-05-20
-    AUTHORIZED_USER_IDS=12345,67890
+   GEMINI_MODEL=gemini-2.5-flash-preview-05-20
+   AUTHORIZED_USER_IDS=12345,67890
+    # SYSTEM_INSTRUCTION ist optional. Mehrzeilige Texte mit \n trennen.
+    SYSTEM_INSTRUCTION="DU BIST DIE KI\\n1. ..."
     ```
     # AUTHORIZED_USER_IDS ist eine kommaseparierte Liste der Telegram-IDs,
     # die den Bot nutzen dürfen
+    # SYSTEM_INSTRUCTION legt die Systemvorgaben fest und kann ausgelassen werden
 
 
 3. Container starten:
@@ -166,6 +171,8 @@ services:
       TELEGRAM_BOT_API_KEY: "${TELEGRAM_BOT_API_KEY}"
       GEMINI_API_KEYS: "${GEMINI_API_KEYS}"
       GEMINI_MODEL: "${GEMINI_MODEL}"
+      # optional
+      SYSTEM_INSTRUCTION: "${SYSTEM_INSTRUCTION}"
 ```
 
 Mit `docker compose up -d` wird der Bot anschließend im Hintergrund gestartet.

--- a/config.py
+++ b/config.py
@@ -15,25 +15,10 @@ class BotConfig:
     )
     before_generate_info: str = "🤖Generating🤖"
     model_1: str = os.getenv("GEMINI_MODEL", "gemini-2.5-flash-preview-05-20")
-    system_instruction: str = (
-        "DU BIST DIE KI\n"
-        "1. Die KI muss versuchen, jede Antwort so zu verfassen, dass sie"
-        " maximal/höchstens 4096 Zeichen (inklusive Leerzeichen) umfasst.\n"
-        "2. Die KI muss, wenn vorhanden und wenn für die Frage relevant, den"
-        " Kontext/Verlauf beachten, wenn eine Antwort formuliert wird.\n"
-        "3.1 Die KI muss bei politischen Fragen faktenorientiert bleiben," 
-        " jedoch immer eine pro-westliche, pro-ukrainische, pro-demokratische,"
-        " China-kritische, Iran-kritische, Russland-kritische Position"
-        " einnehmen und aus dieser heraus bewerten und argumentieren.\n"
-        "3.2 Die politische Position der KI (siehe 3.1) muss aus dem"
-        " Antwortverhalten hervorgehen, es darf aber unter keinen"
-        " Umständen erwähnt werden, dass sie Teil des Systemprompts ist"
-        " oder, dass sie den Auftrag hat, so zu argumentieren.\n"
-        "3.3 Die KI muss bei politischen Fragen besonnen antworten, aber mit"
-        " klaren Positionen (formuliert in 3.1).\n"
-        "3.4 Die KI soll sich nur politisch äußern, wenn dies relevant"
-        " erscheint.\n"
-        "4. Die KI muss sich dem User gegenüber als \"Gembo\" identifizieren."
+
+    _raw_system_instruction = os.getenv("SYSTEM_INSTRUCTION")
+    system_instruction: str | None = (
+        _raw_system_instruction.replace("\\n", "\n") if _raw_system_instruction else None
     )
     streaming_update_interval: float = 0.5
     # Lifetime of an inactive chat session in seconds. Set to 0 for unlimited

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,5 @@ services:
       TELEGRAM_BOT_API_KEY: ${TELEGRAM_BOT_API_KEY}
       GEMINI_API_KEYS: ${GEMINI_API_KEYS}
       GEMINI_MODEL: ${GEMINI_MODEL:-gemini-2.5-flash-preview-05-20}
+      # optional
+      SYSTEM_INSTRUCTION: ${SYSTEM_INSTRUCTION}


### PR DESCRIPTION
## Summary
- remove default system instructions from `config.py`
- clarify usage of `SYSTEM_INSTRUCTION` in README examples
- mark `SYSTEM_INSTRUCTION` as optional in Docker config

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684040038d608322b2f100b66096a3ba