### PR TITLE
Remove /youtube from menu, improve link handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@ Gesprächsverlauf und zeigt Antworten stückweise an.
 - Verlauf bleibt gespeichert, bis `/clear` aufgerufen oder der Bot
   neu gestartet wird
 - Bilder verstehen: Fotos oder Bilddateien können mit oder ohne Bildunterschrift
-  gesendet werden. Die Caption wird als Prompt genutzt und das Ergebnis als
+-  gesendet werden. Die Caption wird als Prompt genutzt und das Ergebnis als
   Antwort ausgegeben.
-- YouTube-Videos analysieren: Link mit /youtube und Frage schicken oder erst den
-  Link senden und danach die Frage stellen
+- YouTube-Videos analysieren: Link senden und die Frage entweder in einer
+  separaten Nachricht oder direkt zusammen mit dem Link stellen. Der Befehl
+  `/youtube` ist weiterhin nutzbar, erscheint aber nicht im Menü.
 - Nutzbar in privaten Chats oder Gruppen
 - Überwacht Tokenverbrauch und API-Limits, um Free-Tier-Fehler zu vermeiden
 
@@ -196,8 +197,9 @@ und den Container beziehungsweise das Programm neu zu starten.
 Im Privatchat können Fragen direkt ohne Befehl gesendet werden.
 Fotos oder Bilddateien können ebenfalls geschickt werden. Eine angefügte
 Beschriftung dient dabei als Prompt für Gemini.
-YouTube-Links funktionieren ähnlich: einfach den Link senden, dann eine Frage
-nachschieben, oder den Befehl `/youtube` mit Link und Frage nutzen.
+YouTube-Links funktionieren ähnlich: Link schicken und die Frage entweder
+nachträglich oder gemeinsam mit dem Link stellen. Der Befehl `/youtube` steht
+weiterhin zur Verfügung.
 
 ## Lizenz
 

--- a/handlers.py
+++ b/handlers.py
@@ -96,7 +96,7 @@ async def gemini_private_handler(message: Message, bot: TeleBot) -> None:
     match = YOUTUBE_RE.search(m)
     if match:
         url = match.group(0)
-        prompt = m[match.end():].strip()
+        prompt = (m[: match.start()] + m[match.end() :]).strip()
         if not prompt:
             pending_youtube[message.from_user.id] = url
             await bot.reply_to(message, "What would you like to do with this video?")

--- a/main.py
+++ b/main.py
@@ -58,7 +58,6 @@ async def main() -> None:
     await bot.set_my_commands(
         commands=[
             telebot.types.BotCommand("clear", "Clear all history"),
-            telebot.types.BotCommand("youtube", "Ask about a YouTube video"),
         ],
     )
     # Init commands


### PR DESCRIPTION
## Summary
- remove `/youtube` command from the Telegram command menu
- allow prompts before or after a YouTube link
- clarify README about new usage

## Testing
- `python -m py_compile handlers.py main.py gemini.py`

------
https://chatgpt.com/codex/tasks/task_e_6840476e219c8322819831bffd3152f7