### PR TITLE
Improve Markdown handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,19 @@ YouTube-Links funktionieren ähnlich: Link schicken und die Frage entweder
 nachträglich oder gemeinsam mit dem Link stellen. Der Befehl `/youtube` steht
 weiterhin zur Verfügung.
 
+### Hinweis zur Textformatierung
+
+Telegram unterstützt nur eine eingeschränkte Form von Markdown. Um Fehler
+bei der Darstellung zu vermeiden, kann über die Umgebungsvariable
+`SYSTEM_INSTRUCTION` festgelegt werden, dass das Modell seine Antworten bereits
+im passenden *MarkdownV2*-Format liefert. Ein Beispiel für die `.env`-Datei:
+
+```env
+SYSTEM_INSTRUCTION="Antworte immer in korrektem MarkdownV2 und entkomme alle Sonderzeichen, die Telegram benötigt."
+```
+
+Damit sind keine zusätzlichen Skripte nötig, um längere Texte sicher zu übermitteln.
+
 ## Lizenz
 
 Dieses Projekt steht unter der [Apache‑2.0‑Lizenz](LICENSE).

--- a/gemini.py
+++ b/gemini.py
@@ -214,7 +214,13 @@ async def gemini_stream(
         if sources:
             final_text += "\n\n" + sources
 
-        await safe_edit(bot, sent_message, final_text, parse_markdown=False)
+        await safe_edit(
+            bot,
+            sent_message,
+            final_text,
+            markdown=True,
+            escape_text=False,
+        )
 
         if usage_tokens is not None:
             rate_limiter.record(usage_tokens)
@@ -223,7 +229,7 @@ async def gemini_stream(
         logger.exception("Gemini API error")
         msg = f"{error_info}\nAPI error {exc.code}: {exc.message}"
         if sent_message:
-            await safe_edit(bot, sent_message, msg, parse_markdown=False)
+            await safe_edit(bot, sent_message, msg, markdown=False)
         else:
             await bot.reply_to(message, msg)
     except Exception as exc:  # pragma: no cover - network issues
@@ -233,7 +239,7 @@ async def gemini_stream(
                 bot,
                 sent_message,
                 f"{error_info}\nError details: {exc}",
-                parse_markdown=False,
+                markdown=False,
             )
         else:
             await bot.reply_to(message, f"{error_info}\nError details: {exc}")

--- a/utils.py
+++ b/utils.py
@@ -11,18 +11,23 @@ logger = logging.getLogger(__name__)
 
 
 async def safe_edit(
-    bot: TeleBot, message: Message, text: str, *, parse_markdown: bool = True
+    bot: TeleBot,
+    message: Message,
+    text: str,
+    *,
+    markdown: bool = True,
+    escape_text: bool = True,
 ) -> None:
     """Edit ``message`` with ``text`` handling markdown errors."""
     try:
         await bot.edit_message_text(
-            escape(text) if parse_markdown else text,
+            escape(text) if markdown and escape_text else text,
             chat_id=message.chat.id,
             message_id=message.message_id,
-            parse_mode="MarkdownV2" if parse_markdown else None,
+            parse_mode="MarkdownV2" if markdown else None,
         )
     except Exception as exc:  # Telegram API may reject Markdown
-        if "parse markdown" in str(exc).lower() and parse_markdown:
-            await safe_edit(bot, message, text, parse_markdown=False)
+        if "parse markdown" in str(exc).lower() and markdown:
+            await safe_edit(bot, message, text, markdown=False, escape_text=False)
         elif "message is not modified" not in str(exc).lower():
             logger.error("Error updating message: %s", exc)


### PR DESCRIPTION
## Summary
- remove `format_text.py` helper script
- mention SYSTEM_INSTRUCTION approach in README
- handle Markdown escaping inside utils
- send final Gemini responses as Markdown

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_68404e367ad48322b6b5579c6fc02777