### PR TITLE
Split long responses into multiple messages

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -7,6 +7,24 @@ from telebot import TeleBot
 from telebot.types import Message
 from md2tgmd import escape
 
+MAX_MESSAGE_LENGTH = 4096
+
+
+def split_text(text: str, max_length: int = MAX_MESSAGE_LENGTH) -> list[str]:
+    """Split ``text`` into chunks no longer than ``max_length``.
+
+    Tries to split on newline boundaries when possible.
+    """
+    chunks: list[str] = []
+    while len(text) > max_length:
+        split_at = text.rfind("\n", 0, max_length)
+        if split_at == -1:
+            split_at = max_length
+        chunks.append(text[:split_at])
+        text = text[split_at:]
+    chunks.append(text)
+    return chunks
+
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
## Summary
- ensure text longer than 4096 characters is split into multiple chunks
- limit streaming edits once the message length approaches Telegram's maximum

## Testing
- `python -m py_compile gemini.py utils.py handlers.py config.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_68405b571d74832284eda0bccf12b9b2