### PR TITLE
Add PDF and audio input support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Gesprächsverlauf und zeigt Antworten stückweise an.
 - Bilder verstehen: Fotos oder Bilddateien können mit oder ohne Bildunterschrift
 -  gesendet werden. Die Caption wird als Prompt genutzt und das Ergebnis als
   Antwort ausgegeben.
+- PDF-Dateien verstehen: Hochgeladene PDFs (bis 20 MB) lassen sich
+  zusammenfassen oder durchsuchen. Eine optionale Beschriftung dient als Prompt.
+- Audiodateien verstehen: Sprach- oder Musikdateien können analysiert oder
+  transkribiert werden. Auch hier kann eine Caption als Frage genutzt werden.
 - YouTube-Videos analysieren: Link senden und die Frage entweder in einer
   separaten Nachricht oder direkt zusammen mit dem Link stellen. Der Befehl
   `/youtube` ist weiterhin nutzbar, erscheint aber nicht im Menü.
@@ -197,6 +201,8 @@ und den Container beziehungsweise das Programm neu zu starten.
 Im Privatchat können Fragen direkt ohne Befehl gesendet werden.
 Fotos oder Bilddateien können ebenfalls geschickt werden. Eine angefügte
 Beschriftung dient dabei als Prompt für Gemini.
+PDF- oder Audiodateien funktionieren genauso: Datei senden und optional eine
+Frage in der Caption stellen.
 YouTube-Links funktionieren ähnlich: Link schicken und die Frage entweder
 nachträglich oder gemeinsam mit dem Link stellen. Der Befehl `/youtube` steht
 weiterhin zur Verfügung.

--- a/gemini.py
+++ b/gemini.py
@@ -268,3 +268,36 @@ async def gemini_youtube_stream(
         file_data=types.FileData(file_uri=youtube_url)
     )
     await gemini_stream(bot, message, [video_part, prompt], model_type)
+
+
+async def gemini_pdf_stream(
+    bot: TeleBot,
+    message: Message,
+    pdf_bytes: bytes,
+    prompt: str,
+    model_type: str,
+) -> None:
+    """Stream a response based on a PDF file and prompt."""
+
+    pdf_part = types.Part.from_bytes(
+        data=pdf_bytes,
+        mime_type="application/pdf",
+    )
+    await gemini_stream(bot, message, [pdf_part, prompt], model_type)
+
+
+async def gemini_audio_stream(
+    bot: TeleBot,
+    message: Message,
+    audio_bytes: bytes,
+    mime_type: str,
+    prompt: str,
+    model_type: str,
+) -> None:
+    """Stream a response based on an audio clip and prompt."""
+
+    audio_part = types.Part.from_bytes(
+        data=audio_bytes,
+        mime_type=mime_type,
+    )
+    await gemini_stream(bot, message, [prompt, audio_part], model_type)

--- a/main.py
+++ b/main.py
@@ -69,6 +69,26 @@ async def main() -> None:
     )
     bot.register_message_handler(handlers.clear, commands=["clear"], pass_bot=True)
     bot.register_message_handler(
+        handlers.gemini_pdf_handler,
+        content_types=["document"],
+        func=lambda m: m.document is not None and m.document.mime_type == "application/pdf",
+        pass_bot=True,
+    )
+    bot.register_message_handler(
+        handlers.gemini_audio_handler,
+        content_types=["audio", "voice", "document"],
+        func=lambda m: (
+            (m.content_type in {"audio", "voice"})
+            or (
+                m.content_type == "document"
+                and m.document is not None
+                and m.document.mime_type
+                and m.document.mime_type.startswith("audio/")
+            )
+        ),
+        pass_bot=True,
+    )
+    bot.register_message_handler(
         handlers.gemini_private_handler,
         func=lambda message: message.chat.type == "private",
         content_types=["text"],


### PR DESCRIPTION
## Summary
- let Gemini process PDF and audio files
- reply to PDF or audio messages with the AI response
- register new Telegram handlers for PDF and audio files
- document PDF and audio support in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68405cb7333c8322b13dd0876b0adf04