### PR TITLE
Use single GEMINI_API_KEY env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ USER bot
 
 # Environment variables for runtime configuration
 ENV TELEGRAM_BOT_API_KEY="" \
-    GEMINI_API_KEYS="" \
+    GEMINI_API_KEY="" \
     GEMINI_MODEL="gemini-2.5-flash-preview-05-20"
 
 CMD ["python", "main.py"]

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ pip install -r requirements.txt
 
 ```env
 TELEGRAM_BOT_API_KEY=<DEIN_TELEGRAM_TOKEN>
-GEMINI_API_KEYS=<DEIN_GEMINI_KEY>
+GEMINI_API_KEY=<DEIN_GEMINI_KEY>
 GEMINI_MODEL=gemini-2.5-flash-preview-05-20
 AUTHORIZED_USER_IDS=12345,67890
 # Optional limits for the free tier (defaults passend zum Modell)
@@ -155,7 +155,7 @@ Mit Docker lässt sich der Bot ohne weitere Abhängigkeiten ausführen.
 
    ```env
    TELEGRAM_BOT_API_KEY=<DEIN_TELEGRAM_TOKEN>
-   GEMINI_API_KEYS=<DEIN_GEMINI_KEY>
+   GEMINI_API_KEY=<DEIN_GEMINI_KEY>
    GEMINI_MODEL=gemini-2.5-flash-preview-05-20
    AUTHORIZED_USER_IDS=12345,67890
    # optional

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     restart: unless-stopped
     environment:
       TELEGRAM_BOT_API_KEY: ${TELEGRAM_BOT_API_KEY}
-      GEMINI_API_KEYS: ${GEMINI_API_KEYS}
+      GEMINI_API_KEY: ${GEMINI_API_KEY}
       GEMINI_MODEL: ${GEMINI_MODEL:-gemini-2.5-flash-preview-05-20}
       # optional
       SYSTEM_INSTRUCTION: ${SYSTEM_INSTRUCTION}

--- a/main.py
+++ b/main.py
@@ -25,9 +25,9 @@ def parse_args() -> argparse.Namespace:
         help="Telegram token",
     )
     parser.add_argument(
-        "GOOGLE_GEMINI_KEY",
+        "GEMINI_API_KEY",
         nargs="?",
-        default=os.getenv("GOOGLE_GEMINI_KEY") or os.getenv("GEMINI_API_KEYS"),
+        default=os.getenv("GEMINI_API_KEY"),
         help="Google Gemini API key",
     )
     return parser.parse_args()
@@ -45,12 +45,12 @@ logger = logging.getLogger(__name__)
 async def main() -> None:
     """Start the bot and register command handlers."""
     # Init bot
-    if not options.tg_token or not options.GOOGLE_GEMINI_KEY:
+    if not options.tg_token or not options.GEMINI_API_KEY:
         raise SystemExit(
             "API keys must be provided via arguments or environment variables"
         )
 
-    gemini.init_client(options.GOOGLE_GEMINI_KEY)
+    gemini.init_client(options.GEMINI_API_KEY)
 
     bot = AsyncTeleBot(options.tg_token)
     await bot.delete_my_commands(scope=None, language_code=None)


### PR DESCRIPTION
## Summary
- unify environment variable to `GEMINI_API_KEY`
- update command line option parsing in `main.py`
- update Dockerfile and docker-compose config
- adjust README instructions

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6840af0c78348322836a419d284d5798