### PR TITLE
Add /start command with help text

### DIFF
--- a/handlers.py
+++ b/handlers.py
@@ -30,6 +30,17 @@ async def _check_authorized(message: Message, bot: TeleBot) -> bool:
     return False
 
 
+async def start_handler(message: Message, bot: TeleBot) -> None:
+    """Reply with a short summary of the bot's features."""
+    if not await _check_authorized(message, bot):
+        return
+    text = (
+        "I can chat with you using Gemini and also understand images, PDFs "
+        "and audio files. Send me text or files and I'll respond. Use /clear to reset our conversation."
+    )
+    await bot.reply_to(message, escape(text), parse_mode="MarkdownV2")
+
+
 async def gemini_stream_handler(message: Message, bot: TeleBot) -> None:
     """Handle /gemini command using the flash model."""
     if not await _check_authorized(message, bot):

--- a/main.py
+++ b/main.py
@@ -56,10 +56,14 @@ async def main() -> None:
     await bot.delete_my_commands(scope=None, language_code=None)
     await bot.set_my_commands(
         commands=[
+            telebot.types.BotCommand("start", "Show help"),
             telebot.types.BotCommand("clear", "Clear all history"),
         ],
     )
     # Init commands
+    bot.register_message_handler(
+        handlers.start_handler, commands=["start"], pass_bot=True
+    )
     bot.register_message_handler(
         handlers.gemini_stream_handler, commands=["gemini"], pass_bot=True
     )


### PR DESCRIPTION
## Summary
- implement `start_handler` to show a short capabilities overview
- register `/start` command and list it in bot commands

## Testing
- `python -m py_compile handlers.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_6840b5b6eb108322839222ed0394fb0f