### PR TITLE
Add session TTL configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ AUTHORIZED_USER_IDS=12345,67890
 # Optional limits for the free tier (defaults passend zum Modell)
 GEMINI_RPM_LIMIT=10
 GEMINI_TPM_LIMIT=250000
+# Lifetime of inactive sessions in seconds (0 = unlimited)
+SESSION_TTL=0
 # SYSTEM_INSTRUCTION ist optional. Mehrzeilige Texte mit \n trennen.
 SYSTEM_INSTRUCTION="DU BIST DIE KI\\n1. ..."
 ```
@@ -159,6 +161,7 @@ Mit Docker lässt sich der Bot ohne weitere Abhängigkeiten ausführen.
    GEMINI_MODEL=gemini-2.5-flash-preview-05-20
    AUTHORIZED_USER_IDS=12345,67890
    # optional
+   SESSION_TTL=0
    SYSTEM_INSTRUCTION="DU BIST DIE KI\n1. ..."
    ```
 

--- a/config.py
+++ b/config.py
@@ -25,7 +25,7 @@ class BotConfig:
     streaming_update_interval: float = 0.5
     # Lifetime of an inactive chat session in seconds. Set to 0 for unlimited
     # lifetime. Sessions exist only while the bot process runs.
-    session_ttl: float = 0.0
+    session_ttl: float = float(os.getenv("SESSION_TTL", 0.0))
     # Comma separated list of allowed Telegram user IDs
     authorized_user_ids: set[int] = field(default_factory=lambda: {
         int(uid)


### PR DESCRIPTION
## Summary
- read `SESSION_TTL` from environment in `BotConfig`
- document the option in `.env` examples

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6840b5b571f083229243561d665130c6