### PR TITLE
Show typing action in handlers

### DIFF
--- a/gemini.py
+++ b/gemini.py
@@ -170,12 +170,14 @@ async def gemini_stream(
     """
 
     sent_message: Message | None = None
+    last_action = time.monotonic()
     try:
         sent_message = await bot.reply_to(
             message,
             before_generate_info,
         )
-
+        await bot.send_chat_action(message.chat.id, "typing")
+        
         chat = chat_manager.get_chat(str(message.from_user.id), model=model_type)
         chat_manager.cleanup()
 
@@ -221,6 +223,9 @@ async def gemini_stream(
                 ):
                     await safe_edit(bot, sent_message, full_response)
                     last_update = time.monotonic()
+            if time.monotonic() - last_action >= 4:
+                await bot.send_chat_action(message.chat.id, "typing")
+                last_action = time.monotonic()
             if chunk.candidates:
                 last_candidate = chunk.candidates[0]
             if chunk.usage_metadata and chunk.usage_metadata.total_token_count:

--- a/handlers.py
+++ b/handlers.py
@@ -43,6 +43,7 @@ async def gemini_stream_handler(message: Message, bot: TeleBot) -> None:
             parse_mode="MarkdownV2",
         )
         return
+    await bot.send_chat_action(message.chat.id, "typing")
     await gemini.gemini_stream(bot, message, m, model_1)
 
 
@@ -66,6 +67,7 @@ async def youtube_command_handler(message: Message, bot: TeleBot) -> None:
         return
 
     prompt = parts[2].strip()
+    await bot.send_chat_action(message.chat.id, "typing")
     await gemini.gemini_youtube_stream(bot, message, url, prompt, model_1)
 
 
@@ -86,6 +88,7 @@ async def gemini_private_handler(message: Message, bot: TeleBot) -> None:
     # If user previously sent a YouTube link without a prompt
     if message.from_user.id in pending_youtube and not YOUTUBE_RE.search(m):
         url = pending_youtube.pop(message.from_user.id)
+        await bot.send_chat_action(message.chat.id, "typing")
         await gemini.gemini_youtube_stream(bot, message, url, m, model_1)
         return
 
@@ -98,10 +101,12 @@ async def gemini_private_handler(message: Message, bot: TeleBot) -> None:
             pending_youtube[message.from_user.id] = url
             await bot.reply_to(message, "What would you like to do with this video?")
             return
+        await bot.send_chat_action(message.chat.id, "typing")
         await gemini.gemini_youtube_stream(bot, message, url, prompt, model_1)
         return
 
     # Regular text
+    await bot.send_chat_action(message.chat.id, "typing")
     await gemini.gemini_stream(bot, message, m, model_1)
 
 
@@ -132,6 +137,7 @@ async def gemini_image_handler(message: Message, bot: TeleBot) -> None:
 
     image_part = types.Part.from_bytes(data=image_bytes, mime_type=mime_type)
     prompt = message.caption.strip() if message.caption else "Describe this image."
+    await bot.send_chat_action(message.chat.id, "typing")
     await gemini.gemini_stream(bot, message, [image_part, prompt], model_1)
 
 
@@ -151,6 +157,7 @@ async def gemini_pdf_handler(message: Message, bot: TeleBot) -> None:
         return
 
     prompt = message.caption.strip() if message.caption else "Summarize this document"
+    await bot.send_chat_action(message.chat.id, "typing")
     await gemini.gemini_pdf_stream(bot, message, pdf_bytes, prompt, model_1)
 
 
@@ -186,4 +193,5 @@ async def gemini_audio_handler(message: Message, bot: TeleBot) -> None:
         return
 
     prompt = message.caption.strip() if message.caption else "Describe this audio clip"
+    await bot.send_chat_action(message.chat.id, "typing")
     await gemini.gemini_audio_stream(bot, message, audio_bytes, mime_type, prompt, model_1)


### PR DESCRIPTION
## Summary
- notify users the bot is working by sending typing action
- keep typing indication alive while streaming

## Testing
- `python -m py_compile handlers.py gemini.py main.py config.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_6840b5a7c3008322813b2d0c3340a7af