### PR TITLE
Fix bundestag function parsing

### DIFF
--- a/bundestag.py
+++ b/bundestag.py
@@ -1,6 +1,5 @@
 """Access helpers for the Bundestag DIP API."""
 
-from __future__ import annotations
 import logging
 from typing import Any, Dict
 from urllib.parse import urlencode


### PR DESCRIPTION
## Summary
- remove postponed evaluation of annotations in `bundestag.py`

The Gemini SDK failed to parse the `dip_fetch` tool due to stringified type hints. Dropping the `__future__` import leaves standard annotations so the SDK can build the schema correctly.

## Testing
- `python -m py_compile bundestag.py gemini.py handlers.py utils.py main.py config.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840db92fba083229ce1b5770b7f9ab4