### PR TITLE
Add option to disable Gemini tool usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,14 @@ GEMINI_TPM_LIMIT=250000
 DIP_API_KEY=<DEIN_DIP_KEY>
 # Lifetime of inactive sessions in seconds (0 = unlimited)
 SESSION_TTL=0
+# Set to false if the chosen model does not support tools
+ENABLE_TOOLS=true
 # SYSTEM_INSTRUCTION ist optional. Mehrzeilige Texte mit \n trennen.
 SYSTEM_INSTRUCTION="DU BIST DIE KI\\n1. ..."
 ```
 
 `AUTHORIZED_USER_IDS` ist eine kommaseparierte Liste der Telegram-IDs, die den Bot nutzen dürfen. `SYSTEM_INSTRUCTION` legt die Systemvorgaben fest und kann weggelassen werden. Mehrzeilige Texte werden mit `\n` getrennt. Das Modell kann jederzeit durch Anpassen von `GEMINI_MODEL` geändert werden. Speichern und die Datei schließen.
+`ENABLE_TOOLS` aktiviert die Google-Suche und Bundestag-Funktionen. Falls dein Modell diese Funktionen nicht unterstützt, setze den Wert auf `false`.
 
 ### Sicherheitseinstellungen
 
@@ -165,11 +168,15 @@ Mit Docker lässt sich der Bot ohne weitere Abhängigkeiten ausführen.
    AUTHORIZED_USER_IDS=12345,67890
    # optional
    SESSION_TTL=0
+   ENABLE_TOOLS=true
    SYSTEM_INSTRUCTION="DU BIST DIE KI\n1. ..."
    ```
 
-   `AUTHORIZED_USER_IDS` ist eine kommaseparierte Liste der Telegram-IDs,
-   die den Bot nutzen dürfen. `SYSTEM_INSTRUCTION` kann weggelassen werden.
+`AUTHORIZED_USER_IDS` ist eine kommaseparierte Liste der Telegram-IDs,
+  die den Bot nutzen dürfen. `SYSTEM_INSTRUCTION` kann weggelassen werden.
+`ENABLE_TOOLS` schaltet die zusätzlichen Such- und Bundestag-Funktionen ein und
+  sollte auf `false` gesetzt werden, wenn das genutzte Modell keine Tools
+  unterstützt.
 
 3. **Container starten**
 

--- a/config.py
+++ b/config.py
@@ -36,6 +36,11 @@ class BotConfig:
     gemini_rpm_limit: int = int(os.getenv("GEMINI_RPM_LIMIT", 10))
     gemini_tpm_limit: int = int(os.getenv("GEMINI_TPM_LIMIT", 250000))
     dip_api_key: str | None = os.getenv("DIP_API_KEY")
+    enable_tools: bool = os.getenv("ENABLE_TOOLS", "true").lower() not in {
+        "false",
+        "0",
+        "no",
+    }
 
 
 conf = BotConfig()

--- a/gemini.py
+++ b/gemini.py
@@ -38,10 +38,11 @@ class ChatManager:
             return session.chat
 
         client = _ensure_client()
+        tools = [search_tool, *bundestag_tools] if conf.enable_tools else None
         chat = client.aio.chats.create(
             model=model,
             config=types.GenerateContentConfig(
-                tools=[search_tool, *bundestag_tools],
+                tools=tools,
                 system_instruction=conf.system_instruction,
                 safety_settings=safety_settings,
             ),


### PR DESCRIPTION
## Summary
- allow disabling tools via `ENABLE_TOOLS` env var
- conditionally include tools in chat creation
- document the new option in README

## Testing
- `python -m py_compile bundestag.py gemini.py handlers.py main.py utils.py config.py`

------
https://chatgpt.com/codex/tasks/task_e_6840ddf0e0b88322a64853f8f3f39c0f