### PR TITLE
Add URL context integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Gesprächsverlauf und zeigt Antworten stückweise an.
 - Bilder verstehen: Fotos oder Bilddateien können mit oder ohne Bildunterschrift gesendet werden. Die Caption wird als Prompt genutzt und das Ergebnis als Antwort ausgegeben.
 - PDF-Dateien verstehen: Hochgeladene PDFs (bis 20 MB) lassen sich zusammenfassen oder durchsuchen. Eine optionale Beschriftung dient als Prompt.
 - Audiodateien verstehen: Sprach- oder Musikdateien können analysiert oder transkribiert werden. Auch hier kann eine Caption als Frage genutzt werden.
+- Webseiten-Inhalte analysieren: Enthält ein Prompt Links, werden diese über das URL-Context-Tool geladen.
 - Web-Suche über Google für aktuelle Informationen (sofern Tools aktiviert)
 - Nutzbar in privaten Chats oder Gruppen
 - Überwacht Tokenverbrauch und API-Limits, um Free-Tier-Fehler zu vermeiden
@@ -224,6 +225,7 @@ Frage in der Caption stellen.
 YouTube-Links funktionieren ähnlich: Link schicken und die Frage entweder
 nachträglich oder gemeinsam mit dem Link stellen. Der Befehl `/youtube` ist
 weiterhin nutzbar, erscheint aber nicht im Menü.
+- Enthält eine Nachricht weitere Links, analysiert der Bot deren Inhalte automatisch und nutzt sie als Kontext.
 
 ### Hinweis zur Textformatierung
 

--- a/utils.py
+++ b/utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from telebot import TeleBot
 from telebot.types import Message
 from md2tgmd import escape
@@ -27,6 +28,19 @@ def split_text(text: str, max_length: int = MAX_MESSAGE_LENGTH) -> list[str]:
 
 
 logger = logging.getLogger(__name__)
+
+
+URL_RE = re.compile(r"https?://[^\s]+")
+
+
+def extract_urls(text: str) -> list[str]:
+    """Return a list of URLs found in ``text``."""
+    return URL_RE.findall(text)
+
+
+def remove_urls(text: str) -> str:
+    """Return ``text`` with any URLs removed."""
+    return URL_RE.sub("", text).strip()
 
 
 async def safe_edit(


### PR DESCRIPTION
## Summary
- support automatic URL context in gemini_stream
- extract and remove links from prompts in handlers
- process URL context for images, audio, PDF, youtube links and plain text
- document new ability to analyze links

## Testing
- `python -m py_compile handlers.py gemini.py utils.py config.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_6840e77387e88322a3fb16f242395737