### PR TITLE
Fix streaming split bug

### DIFF
--- a/gemini.py
+++ b/gemini.py
@@ -234,9 +234,14 @@ async def gemini_stream(
                     leftover = buffers[-1][MAX_MESSAGE_LENGTH:]
                     await safe_edit(bot, messages[-1], part)
                     buffers[-1] = part
+                    send_text = (
+                        escape(leftover[:MAX_MESSAGE_LENGTH])
+                        if leftover
+                        else "\u200b"
+                    )
                     new_msg = await bot.send_message(
                         sent_message.chat.id,
-                        escape(leftover) if leftover else "\u200b",
+                        send_text,
                         parse_mode="MarkdownV2",
                     )
                     messages.append(new_msg)


### PR DESCRIPTION
## Summary
- fix streaming message splitting logic to handle leftovers exceeding Telegram limit

## Testing
- `python -m py_compile main.py gemini.py handlers.py utils.py config.py`

------
https://chatgpt.com/codex/tasks/task_e_6840ec9104f883229085b11d435e3df1